### PR TITLE
Added github action Build and publish container image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,35 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main  # Trigger on pushes to the main branch
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+
+    steps:
+      # This step is a workaround for an issue whereby github artifacts expects repositories to have only lower case names
+      # See https://github.com/docker/build-push-action/issues/37
+      - name: PrepareReg Names
+        run: |
+          echo IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+          echo IMAGE_TAG=$(echo ${{ github.ref }} | tr '[:upper:]' '[:lower:]' | awk '{split($0,a,"/"); print a[3]}') >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push with commit SHA tag
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ env.IMAGE_REPOSITORY }}:latest, ghcr.io/${{ env.IMAGE_REPOSITORY }}:${{ github.sha }}


### PR DESCRIPTION
Merging this PR should be all you need to have github actions auto build a container image any time you merge changes to main.

No fancy versioning or anything, but anyone pulling ` ghcr.io/jonjonsson/emby-mdblist-collection-creator:latest` should get the latest on main.

If you're happy with this and get it merged in, I'm happy to draft up an example `docker-compose.yml` so anyone wanting to use this via docker can just copy and paste. 