### PR TITLE
Add instructions for running via the published docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,30 @@ If you encounter any issues, ensure you have followed each step correctly and ha
 
 ### Running the Script in Docker
 
-To run the script in a Docker container, follow these steps:
+To run the script in a Docker container, you will need to mount a configuration file to `/app/config.cfg` but that's it - no ports need exposing.
+
+An example docker run command:
+
+```bash
+docker run -v /path/to/config.cfg:/app/config.cfg ghcr.io/jonjonsson/emby-mdblist-collection-creator
+```
+
+Or use this example compose file:
+
+```yml
+version: '3.8'
+
+services:
+    emby-mdblist-collection-creator:
+        image: ghcr.io/jonjonsson/emby-mdblist-collection-creator:latest
+        volumes:
+            - /path/to/config.cfg:/app/config.cfg
+```
+
+
+### Building the docker image manually
+
+It's not necessary to build the image yourself, but should you choose to, you need these two commands:
 
 1. Build the Docker image:
 


### PR DESCRIPTION
Now that the github actions are working and publishing a working image for you, I've updated the readme for those who want to run it via docker (or more likely compose).

I left the section in about building the docker image but feel free to remove it, I don't think the vast majority of people will need that and those that do should know how to build a docker image anyway. 

Now that you're publishing the image yourself, all people need to do is reference it (`ghcr.io/jonjonsson/emby-mdblist-collection-creator`) in whatever container engine they like.

